### PR TITLE
fix: Causal dml temp

### DIFF
--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/LinearDMLEstimator.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/causal/LinearDMLEstimator.scala
@@ -237,20 +237,18 @@ class LinearDMLEstimator(override val uid: String)
     val dropOutcomePredictedColumnsTransformer = new DropColumns().setCols(outcomePredictionColsToDrop.toArray)
 
 
-    val stage1Pipeline = new Pipeline()
-      .setStages(
-        Array(treatmentModelV1,
-          treatmentResidualDFV1,
-          dropTreatmentPredictedColumnsTransformer,
-          outcomeModelV1,
-          residualsDFV1,
-          dropOutcomePredictedColumnsTransformer,
-          new VectorAssembler()
-            .setInputCols(Array(SchemaConstants.TreatmentResidualColumn))
-            .setOutputCol("treatmentResidualVec")
-            .setHandleInvalid("skip"),
-          new DropColumns().setCols(Array(SchemaConstants.TreatmentResidualColumn))
-      )
+    val stage1Pipeline = new Pipeline().setStages(
+      Array(treatmentModelV1,
+        treatmentResidualDFV1,
+        dropTreatmentPredictedColumnsTransformer,
+        outcomeModelV1,
+        residualsDFV1,
+        dropOutcomePredictedColumnsTransformer,
+        new VectorAssembler()
+          .setInputCols(Array(SchemaConstants.TreatmentResidualColumn))
+          .setOutputCol("treatmentResidualVec")
+          .setHandleInvalid("skip"),
+        new DropColumns().setCols(Array(SchemaConstants.TreatmentResidualColumn)))
     )
     val dataset1 = stage1Pipeline.fit(test).transform(test)
 
@@ -264,7 +262,13 @@ class LinearDMLEstimator(override val uid: String)
         dropTreatmentPredictedColumnsTransformer,
         outcomeModelV2,
         residualsDFV1,
-        dropOutcomePredictedColumnsTransformer))
+        dropOutcomePredictedColumnsTransformer,
+        new VectorAssembler()
+          .setInputCols(Array(SchemaConstants.TreatmentResidualColumn))
+          .setOutputCol("treatmentResidualVec")
+          .setHandleInvalid("skip"),
+        new DropColumns().setCols(Array(SchemaConstants.TreatmentResidualColumn)))
+    )
     val dataset2 = stage2Pipeline.fit(train).transform(train)
     
     val regressor = new GeneralizedLinearRegression()

--- a/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainClassifier.scala
+++ b/core/src/main/scala/com/microsoft/azure/synapse/ml/train/TrainClassifier.scala
@@ -193,38 +193,6 @@ class TrainClassifier(override val uid: String) extends AutoTrainer[TrainedClass
     })
   }
 
-  def getFeaturizedDataAndModel(dataset: Dataset[_]): (DataFrame, PipelineModel, Option[Array[_]], Boolean) = {
-    val labelValues =
-      if (isDefined(labels)) {
-        Some(getLabels)
-      } else {
-        None
-      }
-    // Convert label column to categorical on train, remove rows with missing labels
-    val (convertedLabelDataset, levels) = convertLabel(dataset, getLabelCol, labelValues)
-
-    val (oneHotEncodeCategoricals, modifyInputLayer, numFeatures) = getFeaturizeParams
-
-
-    val featuresToHashTo =
-      if (getNumFeatures != 0) {
-        getNumFeatures
-      } else {
-        numFeatures
-      }
-
-    val nonFeatureColumns = getLabelCol +: getExcludedFeatures
-    val featureColumns = convertedLabelDataset.columns.filter(col => !nonFeatureColumns.contains(col)).toSeq
-
-    val featurizer = new Featurize()
-      .setOutputCol(getFeaturesCol)
-      .setInputCols(featureColumns.toArray)
-      .setOneHotEncodeCategoricals(oneHotEncodeCategoricals)
-      .setNumFeatures(featuresToHashTo)
-    val featurizedModel = featurizer.fit(convertedLabelDataset)
-    (featurizedModel.transform(convertedLabelDataset), featurizedModel, levels, modifyInputLayer)
-  }
-
   def getFeaturizeParams: (Boolean, Boolean, Int) = {
     var oneHotEncodeCategoricals = true
     var modifyInputLayer = false

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/causal/VerifyLinearDMLEstimator.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/causal/VerifyLinearDMLEstimator.scala
@@ -1,10 +1,11 @@
 package com.microsoft.azure.synapse.ml.causal
 
-import com.microsoft.azure.synapse.ml.core.test.base.TestBase
+import com.microsoft.azure.synapse.ml.core.test.fuzzing.{EstimatorFuzzing, TestObject}
 import org.apache.spark.ml.regression.RandomForestRegressor
 import org.apache.spark.ml.classification.LogisticRegression
+import org.apache.spark.ml.util.MLReadable
 
-class VerifyLinearDMLEstimator extends TestBase {
+class VerifyLinearDMLEstimator extends EstimatorFuzzing[LinearDMLEstimator] {
 
   val mockLabelColumn = "Label"
 
@@ -61,4 +62,17 @@ class VerifyLinearDMLEstimator extends TestBase {
     var ldmlModel = ldml.fit(mockDataset)
     assert(ldmlModel.getCi.length == 2)
   }
+
+
+  override def testObjects(): Seq[TestObject[LinearDMLEstimator]] =
+    Seq(new TestObject(new LinearDMLEstimator()
+      .setTreatmentModel(new LogisticRegression())
+      .setTreatmentCol(mockLabelColumn)
+      .setOutcomeModel(new RandomForestRegressor())
+      .setOutcomeCol("col2"),
+    mockDataset))
+
+  override def reader: MLReadable[_] = LinearDMLEstimator
+
+  override def modelReader: MLReadable[_] = LinearDMLModel
 }

--- a/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyTrainClassifier.scala
+++ b/core/src/test/scala/com/microsoft/azure/synapse/ml/train/VerifyTrainClassifier.scala
@@ -129,41 +129,6 @@ class VerifyTrainClassifier extends Benchmarks with EstimatorFuzzing[TrainClassi
     trainScoreDataset(mockLabelCol, dataset, logisticRegressor)
   }
 
-  test("Verify getFeaturizedDataAndModel with setExcludedFeatureCols") {
-    val cat = "Cat"
-    val dog = "Dog"
-    val bird = "Bird"
-    val dataset: DataFrame = spark.createDataFrame(Seq(
-      (0, 2, 0.50, 0.60, dog, cat),
-      (1, 3, 0.40, 0.50, cat, dog),
-      (0, 4, 0.78, 0.99, dog, bird),
-      (1, 5, 0.12, 0.34, cat, dog),
-      (0, 1, 0.50, 0.60, dog, bird),
-      (1, 3, 0.40, 0.50, bird, dog),
-      (0, 3, 0.78, 0.99, dog, cat),
-      (1, 4, 0.12, 0.34, cat, dog),
-      (0, 0, 0.50, 0.60, dog, cat),
-      (1, 2, 0.40, 0.50, bird, dog),
-      (0, 3, 0.78, 0.99, dog, bird),
-      (1, 4, 0.12, 0.34, cat, dog)))
-      .toDF(mockLabelCol, "col1", "col2", "col3", "col4", "col5")
-
-    val model1 = new ValueIndexer().setInputCol("col4").setOutputCol("col4").fit(dataset)
-    val model2 = new ValueIndexer().setInputCol("col5").setOutputCol("col5").fit(dataset)
-    val catDataset = model1.transform(model2.transform(dataset))
-
-    val logisticRegressor =
-      new TrainClassifier()
-        .setModel(new LogisticRegression())
-        .setLabelCol(mockLabelCol)
-        .setFeaturesCol("features")
-        .setExcludedFeatures(Array("col4", "col5"))
-    val (processedDF, _, _, _) = logisticRegressor.getFeaturizedDataAndModel(catDataset)
-
-    val row = processedDF.select("features").head
-    assert(row(0).asInstanceOf[DenseVector].size == 3)
-  }
-
   override val testFitting: Boolean = true
 
   verifyMultiClassCSV("abalone.csv", "Rings", 2, includeNaiveBayes = true)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

_Briefly describe the changes included in this Pull Request._

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
